### PR TITLE
drive current password scheme from config

### DIFF
--- a/src/couch_httpd_auth.erl
+++ b/src/couch_httpd_auth.erl
@@ -372,9 +372,11 @@ maybe_value(Key, Else, Fun) ->
 
 maybe_upgrade_password_hash(Req, UserName, Password, UserProps,
         AuthModule, AuthCtx) ->
+    Upgrade = config:get("couch_httpd_auth", "upgrade_password_on_auth", "true"),
     IsAdmin = lists:member(<<"_admin">>, couch_util:get_value(<<"roles">>, UserProps, [])),
-    case {IsAdmin, couch_util:get_value(<<"password_scheme">>, UserProps, <<"simple">>)} of
-    {false, <<"simple">>} ->
+    case {IsAdmin, Upgrade,
+         couch_util:get_value(<<"password_scheme">>, UserProps, <<"simple">>)} of
+    {false, "true", <<"simple">>} ->
         UserProps2 = proplists:delete(<<"password_sha">>, UserProps),
         UserProps3 = [{<<"password">>, Password} | UserProps2],
         NewUserDoc = couch_doc:from_json_obj({UserProps3}),

--- a/src/couch_users_db.erl
+++ b/src/couch_users_db.erl
@@ -83,7 +83,10 @@ transform_doc(#doc{body={Body}} = Doc) ->
         Body2 = ?replace(Body1, ?DERIVED_KEY, DerivedKey),
         Body3 = ?replace(Body2, ?SALT, Salt),
         Body4 = proplists:delete(?PASSWORD, Body3),
-        Doc#doc{body={Body4}}
+        Doc#doc{body={Body4}};
+    {_ClearPassword, Scheme} ->
+        couch_log:warn("Configured password scheme '~p' not recognised.", [Scheme]),
+        Doc
     end.
 
 % If the doc is a design doc

--- a/src/couch_users_db.erl
+++ b/src/couch_users_db.erl
@@ -21,6 +21,8 @@
 -define(PASSWORD, <<"password">>).
 -define(DERIVED_KEY, <<"derived_key">>).
 -define(PASSWORD_SCHEME, <<"password_scheme">>).
+-define(SIMPLE, <<"simple">>).
+-define(PASSWORD_SHA, <<"password_sha">>).
 -define(PBKDF2, <<"pbkdf2">>).
 -define(ITERATIONS, <<"iterations">>).
 -define(SALT, <<"salt">>).
@@ -58,12 +60,21 @@ before_doc_update(Doc, #db{user_ctx = UserCtx} = Db) ->
 %    newDoc.salt = salt
 %    newDoc.password = null
 transform_doc(#doc{body={Body}} = Doc) ->
-    case couch_util:get_value(?PASSWORD, Body) of
-    null -> % server admins don't have a user-db password entry
+    Scheme = config:get("couch_httpd_auth", "password_scheme", "pbkdf2"),
+    case {couch_util:get_value(?PASSWORD, Body), Scheme} of
+    {null, _} -> % server admins don't have a user-db password entry
         Doc;
-    undefined ->
+    {undefined, _} ->
         Doc;
-    ClearPassword ->
+    {ClearPassword, "simple"} ->
+        Salt = couch_uuids:random(),
+        PasswordSha = couch_passwords:simple(ClearPassword, Salt),
+        Body0 = ?replace(Body, ?PASSWORD_SCHEME, ?SIMPLE),
+        Body1 = ?replace(Body0, ?SALT, Salt),
+        Body2 = ?replace(Body1, ?PASSWORD_SHA, PasswordSha),
+        Body3 = proplists:delete(?PASSWORD, Body2),
+        Doc#doc{body={Body3}};
+    {ClearPassword, "pbkdf2"} ->
         Iterations = list_to_integer(config:get("couch_httpd_auth", "iterations", "1000")),
         Salt = couch_uuids:random(),
         DerivedKey = couch_passwords:pbkdf2(ClearPassword, Salt, Iterations),


### PR DESCRIPTION
Allow administrators to choose whether to upgrade password scheme on next authentication and control over when to switch to using pbkdf2.

BugzID: 47785
