### PR TITLE
Fix `active_size` format conversion in `get_db_info` function

### DIFF
--- a/src/couch_db.erl
+++ b/src/couch_db.erl
@@ -327,8 +327,13 @@ get_db_info(Db) ->
     {ok, FileSize} = couch_file:bytes(Fd),
     {ok, DbReduction} = couch_btree:full_reduce(IdBtree),
     SizeInfo0 = element(3, DbReduction),
-    SizeInfo = if is_record(SizeInfo0, size_info) -> SizeInfo0; true ->
-        #size_info{active=SizeInfo0}
+    SizeInfo = case SizeInfo0 of
+        SI when is_record(SI, size_info) ->
+            SI;
+        {AS, ES} ->
+            #size_info{active=AS, external=ES};
+        SI ->
+            #size_info{active=SI}
     end,
     ActiveSize = active_size(Db, SizeInfo),
     DiskVersion = couch_db_header:disk_version(Header),

--- a/src/couch_db.erl
+++ b/src/couch_db.erl
@@ -332,8 +332,8 @@ get_db_info(Db) ->
             SI;
         {AS, ES} ->
             #size_info{active=AS, external=ES};
-        SI ->
-            #size_info{active=SI}
+        AS ->
+            #size_info{active=AS}
     end,
     ActiveSize = active_size(Db, SizeInfo),
     DiskVersion = couch_db_header:disk_version(Header),

--- a/src/couch_db_updater.erl
+++ b/src/couch_db_updater.erl
@@ -516,13 +516,13 @@ reduce_sizes(nil, _) ->
     nil;
 reduce_sizes(_, nil) ->
     nil;
-reduce_sizes(S1, S2) when is_integer(S1); is_integer(S2) ->
-    reduce_sizes(upgrade_sizes(S1), upgrade_sizes(S2));
 reduce_sizes(#size_info{}=S1, #size_info{}=S2) ->
     #size_info{
         active = S1#size_info.active + S2#size_info.active,
         external = S1#size_info.external + S2#size_info.external
-    }.
+    };
+reduce_sizes(S1, S2) ->
+    reduce_sizes(upgrade_sizes(S1), upgrade_sizes(S2)).
 
 btree_by_seq_reduce(reduce, DocInfos) ->
     % count the number of documents


### PR DESCRIPTION
This is an upstream fix for the proper conversion of active_size format from 2-tuple used in DBCore to #active_size record used in Couch 2.0

BugzID: 47439
