### PR TITLE
Throw bad request for empty POST request body when filtering by doc_ids

### DIFF
--- a/src/couch_changes.erl
+++ b/src/couch_changes.erl
@@ -309,6 +309,8 @@ get_view_qs(Req) ->
 
 get_doc_ids({json_req, {Props}}) ->
     check_docids(couch_util:get_value(<<"doc_ids">>, Props));
+get_doc_ids(#httpd{method='POST', req_body=undefined}) ->
+    throw({bad_request, "`_doc_ids` filter requires JSON body containing doc ids."});
 get_doc_ids(#httpd{method='POST'}=Req) ->
     {Props} = couch_httpd:json_body_obj(Req),
     check_docids(couch_util:get_value(<<"doc_ids">>, Props));


### PR DESCRIPTION
BugzID: 48864
